### PR TITLE
Use q as well as Esc to quit

### DIFF
--- a/src/mod_manager/terminal.rs
+++ b/src/mod_manager/terminal.rs
@@ -279,7 +279,7 @@ impl<'a> Terminal<'a> {
                             self.start_game()?;
                         }
 
-                        KeyCode::Esc => break,
+                        KeyCode::Esc | KeyCode::Char('q') => break,
 
                         _ => continue,
                     },


### PR DESCRIPTION
Now 'q' works as well as escape to quit the console. 'q' is normal for terminal apps so it's more expected for users.