### PR TITLE
Add configurable executable name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The application creates a config file at `~/arma3-mod-launcher-console-config.js
   "game_path": "/Users/user/Library/Application Support/Steam/steamapps/common/Arma 3",
   "workshop_path": "/Users/user/Library/Application Support/Steam/steamapps/workshop/content/107410",
   "custom_mods_path": "/Users/user/arma3-mod-manager-console-custom-mods",
+  "executable_name": "arma3",
   "enabled_mods": [
     
   ],
@@ -65,7 +66,7 @@ The application creates a config file at `~/arma3-mod-launcher-console-config.js
 }
 ````
 
-If the application cannot resolve the correct paths, you can edit them here.
+If the application cannot resolve the correct paths, you can edit them here. The `executable_name` field allows you to specify a different Arma 3 executable name (without the `.app` extension) if needed.
 
 ### Custom Mods
 

--- a/src/mod_manager/config.rs
+++ b/src/mod_manager/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     game_path: String,
     workshop_path: String,
     custom_mods_path: Option<String>, // Optional
+    #[serde(default = "default_executable_name")]
+    executable_name: String,
     #[serde(deserialize_with = "deserialize_mods")]
     enabled_mods: Vec<String>,
     default_args: String,
@@ -38,6 +40,10 @@ where
     Ok(mods)
 }
 
+fn default_executable_name() -> String {
+    "arma3".to_string()
+}
+
 impl Config {
     fn get_save_path() -> AppResult<PathBuf> {
         let home_path = utils::get_home_path()?;
@@ -54,6 +60,7 @@ impl Config {
             game_path,
             workshop_path,
             custom_mods_path,
+            executable_name: default_executable_name(),
             enabled_mods: Vec::new(),
             default_args: "-noSplash -skipIntro -world=empty".to_string(),
         };
@@ -91,6 +98,14 @@ impl Config {
 
     pub fn get_custom_mods_path(&self) -> Option<&Path> {
         self.custom_mods_path.as_deref().map(Path::new)
+    }
+
+    pub fn get_executable_name(&self) -> &str {
+        &self.executable_name
+    }
+
+    pub fn set_executable_name(&mut self, name: String) {
+        self.executable_name = name;
     }
 
     pub fn get_default_args(&self) -> &str {


### PR DESCRIPTION
Add configurable executable name support

- Add executable_name field to config with default value "arma3"
- Add interactive screen to set executable name via 'E' key
- Update game launch logic to use configurable executable name
- Update README with documentation for new executable_name config option

This allows users to specify a different Arma 3 executable name
(without .app extension) if needed for their setup.