### PR TITLE
OS depending config directory to not clutter home directory on MacOS or Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ cargo run
 ````
 
 ## Config
-The application creates a config file at `~/arma3-mod-launcher-console-config.json` which looks like this:
+The application creates a config file which looks like this:
+
+- Windows: `~/arma3-mod-launcher-console-config.json`
+- Linus & MacOS: `~/.config/arma3-mod-launcher-console/config.json`
 
 ````
 {
@@ -83,7 +86,7 @@ Simply move your mods into the custom mods folder. The folder will be alongside 
 `Error: InvalidPath("/Users/user/Library/Application Support/Steam/steamapps/workshop/content/107410")`
 
 **Steps to Resolve**:
-1. **Check Config File**: Verify `~/arma3-mod-manager-console-config.json` has the correct Steam path.
+1. **Check Config File**: Verify config file ( location see above ) has the correct Steam path.
 2. **Ensure Workshop Mods**: Confirm Arma 3 workshop mods are installed via Steam.
 3. **Locate Steam Path**:
    - For macOS: check for `~/Library/Application Support/Steam`

--- a/src/mod_manager/terminal.rs
+++ b/src/mod_manager/terminal.rs
@@ -112,7 +112,13 @@ impl<'a> Terminal<'a> {
                 cursor::MoveTo(0, 9),
                 Print("Press <2> to edit Game Path"),
                 cursor::MoveTo(0, 11),
-                Print("Press <ENTER> to Save and Continue"),
+                Print(format!(
+                    "Press <ENTER> to Save ({}) and Continue",
+                    match Config::get_save_path() {
+                        Ok(path) => path.display().to_string(),
+                        Err(e) => format!("Error: {}", e),
+                    }
+                )),
                 cursor::MoveTo(0, 12),
                 Print("Press <ESC> or <Q> to Quit"),
             )?;

--- a/src/mod_manager/terminal.rs
+++ b/src/mod_manager/terminal.rs
@@ -339,10 +339,18 @@ impl<'a> Terminal<'a> {
                 "Arma 3 Mod Manager Console ({})",
                 env!("CARGO_PKG_VERSION")
             )),
+            cursor::MoveTo(0, top_offset + 1),
+            Print(format!(
+                "Config file: {}",
+                match Config::get_save_path() {
+                    Ok(path) => path.display().to_string(),
+                    Err(e) => format!("Error: {}", e),
+                }
+            )),
             SetForegroundColor(Color::Reset)
         )?;
 
-        top_offset += 2;
+        top_offset += 3;
 
         let enabled_mods = self.mod_manager.loaded_mods.filter(|m| m.enabled).len();
         let total_mods = self.mod_manager.loaded_mods.all_items().len();

--- a/src/mod_manager/utils.rs
+++ b/src/mod_manager/utils.rs
@@ -11,6 +11,14 @@ use crate::errors::{AppError, AppResult};
 
 use super::Mod;
 
+pub fn ensure_directory_exists(path: &PathBuf) -> AppResult<()> {
+    if !path.exists() {
+        fs::create_dir_all(path)
+            .map_err(|_| AppError::InvalidPath(path.to_string_lossy().to_string()))?;
+    }
+    Ok(())
+}
+
 pub fn get_home_path() -> AppResult<OsString> {
     match env::var_os("HOME") {
         Some(home_path) => Ok(home_path),


### PR DESCRIPTION
I don't like my HOME directory being cluttered with config files.

PR includes changes to use config directory for MacOS & Linux at `~/.config/arma3-mod-manager-console/config.json`.
Windows config path is unchanged.

Printing the config path in the initial setup screen and on the normal runtime screen.

Applied standard source formatting provided by VS Code functionality.